### PR TITLE
Add GITHUB_SHA environment variable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ const run = async () => {
         */
         let command: string = `run --workdir ${CONTAINER_WORKSPACE} -v ${process.env.GITHUB_WORKSPACE}:${CONTAINER_WORKSPACE} `;
         command += ` -v ${process.env.HOME}/.azure:/root/.azure -v ${TEMP_DIRECTORY}:${CONTAINER_TEMP_DIRECTORY} `;
-        command += `-e GITHUB_WORKSPACE=${CONTAINER_WORKSPACE} --name ${CONTAINER_NAME}`;
+        command += `-e GITHUB_WORKSPACE=${CONTAINER_WORKSPACE} -e GITHUB_SHA=${process.env.GITHUB_SHA} --name ${CONTAINER_NAME}`;
         command += ` mcr.microsoft.com/azure-cli:${azcliversion} ${startCommand}`;
         console.log(`${START_SCRIPT_EXECUTION_MARKER}${azcliversion}`);
         await executeDockerCommand(command);

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,8 @@ const run = async () => {
         */
         let command: string = `run --workdir ${CONTAINER_WORKSPACE} -v ${process.env.GITHUB_WORKSPACE}:${CONTAINER_WORKSPACE} `;
         command += ` -v ${process.env.HOME}/.azure:/root/.azure -v ${TEMP_DIRECTORY}:${CONTAINER_TEMP_DIRECTORY} `;
-        command += `-e GITHUB_WORKSPACE=${CONTAINER_WORKSPACE} -e GITHUB_SHA=${process.env.GITHUB_SHA} --name ${CONTAINER_NAME}`;
+        command += `-e GITHUB_WORKSPACE=${CONTAINER_WORKSPACE} -e GITHUB_SHA=${process.env.GITHUB_SHA} `;
+        command += `--name ${CONTAINER_NAME} `;
         command += ` mcr.microsoft.com/azure-cli:${azcliversion} ${startCommand}`;
         console.log(`${START_SCRIPT_EXECUTION_MARKER}${azcliversion}`);
         await executeDockerCommand(command);


### PR DESCRIPTION
This PR makes the GITHUB_SHA default environment variable available to use in inlineScript.
This change does not address the issue #7 since it does not pass down all the environment variables (default ones and ones set by the user). This is stopgap solution that should be superseded by a more scalable solution that addresses issue #7 completely.

Also added newline at EOF