### PR TITLE
Secure workflow strategy for Azure CLI output configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Please note that the action executes Az CLI script in a docker container. This m
   1. If script sets up an environment variable, it will not take effect in host and hence subsequent actions shouldn't rely on such environment variable.
   2. There is some restriction on how cross action file read/write is done. GITHUB_WORKSPACE directory in host is mapped to working directory inside container. So, if the action wants to create a file, which will be read by subsequent actions, it should do so within current working directory tree.
 
-> **Warning**
-> Without redirecting Azure CLI commands’ output, it will be printed to stdout stream and the build log. To prevent this, you may disable Azure CLI commands’ output by setting the environment variable `AZURE_CORE_OUTPUT` to `none`. If you need the output of a specific command, you can add argument `--output json` to restore its output. For more information about the configuration settings and output format of Azure CLI, see [CLI configuration values and environment variables](https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-values-and-environment-variables).
+> [!WARNING]
+> By default, Azure CLI commands’ output is printed to the stdout stream. Without redirecting the stdout stream, contents in it will be stored in the build logs of the action. You may configure Azure CLI to not print any output by setting the environment variable `AZURE_CORE_OUTPUT` to `none`. If you need the output of a specific command, you can add argument `--output json` to restore its output. For more information about the configuration settings and output format of Azure CLI, see [CLI configuration values and environment variables](https://learn.microsoft.com/cli/azure/azure-cli-configuration#cli-configuration-values-and-environment-variables).
 
 ## Sample workflow
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please note that the action executes Az CLI script in a docker container. This m
   2. There is some restriction on how cross action file read/write is done. GITHUB_WORKSPACE directory in host is mapped to working directory inside container. So, if the action wants to create a file, which will be read by subsequent actions, it should do so within current working directory tree.
 
 > [!WARNING]
-> By default, Azure CLI commands’ output is printed to the stdout stream. Without redirecting the stdout stream, contents in it will be stored in the build logs of the action. You may configure Azure CLI to not print any output by setting the environment variable `AZURE_CORE_OUTPUT` to `none`. If you need the output of a specific command, you can add argument `--output json` to restore its output. For more information about the configuration settings and output format of Azure CLI, see [CLI configuration values and environment variables](https://learn.microsoft.com/cli/azure/azure-cli-configuration#cli-configuration-values-and-environment-variables).
+> By default, the output of Azure CLI commands print to the stdout stream and are stored in the build logs of the action. Configure Azure CLI to _not_ show output in the console screen or print in the log by setting the environment variable `AZURE_CORE_OUTPUT` to `none`. If you need the output of a specific command, override the default setting using the argument `--output` with your format of choice. For more information on output options with the Azure CLI, see [Format output](https://learn.microsoft.com/cli/azure/format-output-azure-cli).
 
 ## Sample workflow
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Please note that the action executes Az CLI script in a docker container. This m
   1. If script sets up an environment variable, it will not take effect in host and hence subsequent actions shouldn't rely on such environment variable.
   2. There is some restriction on how cross action file read/write is done. GITHUB_WORKSPACE directory in host is mapped to working directory inside container. So, if the action wants to create a file, which will be read by subsequent actions, it should do so within current working directory tree.
 
+> **Warning**
+> Without redirecting Azure CLI commands’ output, it will be printed to stdout stream and the build log. To prevent this, you may disable Azure CLI commands’ output by setting the environment variable `AZURE_CORE_OUTPUT` to `none`. If you need the output of a specific command, you can add argument `--output json` to restore its output. For more information about the configuration settings and output format of Azure CLI, see [CLI configuration values and environment variables](https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-values-and-environment-variables).
+
 ## Sample workflow
 
 ### Dependencies on other GitHub Actions


### PR DESCRIPTION
When creating workflows, especially in a public repository, it's crucial to ensure that your build logs don't expose any sensitive data. You should proactively safeguard sensitive information by [storing it as secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions), [masking any sensitive value in logs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log) and [setting the repositories and CI instances to private](https://docs.github.com/en/repositories/managing-your-repositorys-settigs-and-features/managing-repository-settings/setting-repository-visibility) if they don't need to be public. 

Moreover, Azure CLI commands output to both stdout stream and the build log by default. Azure CLI suggests us to protect output information by setting the output to `none`, see https://aka.ms/clisecrets. You may configure Azure CLI to not print any output by setting the environment variable `AZURE_CORE_OUTPUT` to `none` when you invoke Azure CLI commands in your workflow. For example,
```yaml
# File: .github/workflows/workflow.yml

on: [push]

name: Redirect Azure CLI commands' output to none

jobs:
  build-and-deploy:
    runs-on: ubuntu-latest
    steps:
    - uses: azure/login@v1
      with:
        creds: ${{ secrets.AZURE_CREDENTIALS }}
    
    - uses: azure/CLI@v1
      env:
          AZURE_CORE_OUTPUT: none
        with:
          azcliversion: latest
          inlineScript: |
            az webapp config appsettings set --resource-group <resourcegroupname> --name <sitename> --settings <settings>
```
For detailed guidance on how to set environment variables in a workflow, refer to the GitHub doc:  https://docs.github.com/en/actions/learn-github-actions/variables.

When you need the output of a specific command, you can add argument `--output json` to restore its output. For example,
```
$settings = (az webapp config appsettings list --resource-group <resourcegroupname> --name <sitename> --output json)
```
For more information about the configuration settings and output format of Azure CLI, see [CLI configuration values and environment variables](https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-values-and-environment-variables).