### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 With Azure CLI GitHub Action, you can automate your workflow by executing [Azure CLI](https://github.com/Azure/azure-cli) commands to manage Azure resources inside of an Action.
 
-The action executes the Azure CLI Bash script on a user defined Azure CLI version. If the user does not specify a version, the version of Azure CLI installed on agent is used. If there is no version of Azure CLI found on the agent, the action falls back the version to `latest`.
+The action executes the Azure CLI Bash script on a user defined Azure CLI version. If the user does not specify a version, the version of Azure CLI installed on the agent is used. If there is no version of Azure CLI found on the agent, the action falls back the version to `latest`.
 Read more about various Azure CLI versions [here](https://github.com/Azure/azure-cli/releases).
 
 - `azcliversion` – **Optional** Example: 2.30.0, Default: set to az cli version of the agent.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ The definition of this GitHub Action is in [action.yml](https://github.com/Azure
 ## Sample workflow
 
 ### Dependencies on other GitHub Actions
-* [Azure Login](https://github.com/Azure/login) – **Optional**  Login with your Azure credentials, required only for authentication via azure credentials. Authentication via connection strings or keys do not require this step.
-> [!NOTE] 
-> Make sure to either use default value of `azcliversion` or version above 2.30.0 for all the workflows using `GitHub hosted agents`.
-* [Checkout](https://github.com/actions/checkout) – **Optional** To execute the scripts present in your repository
+* [Azure Login](https://github.com/Azure/login) – **Optional** Login with your Azure credentials, required only for authentication via azure credentials. If you use this action, make sure to either use the default value of `azcliversion` or `azcliversion >= 2.30.0` for all the workflows. Authentication via connection strings or keys do not require this step.
+* [Checkout](https://github.com/actions/checkout) – **Optional** To execute the scripts present in your repository.
 
 ### Workflow to execute an Azure CLI script of a specific CLI version
 ```
@@ -87,7 +85,7 @@ jobs:
           chmod +x $GITHUB_WORKSPACE/sampleScript.sh
           $GITHUB_WORKSPACE/sampleScript.sh
 ```
-  * [GITHUB_WORKSPACE](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners) is the environment variable provided by GitHub which represents the root of your repository.
+* [`GITHUB_WORKSPACE`](https://docs.github.com/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#file-systems) is the environment variable provided by GitHub which represents the root of your repository.
 
 # Getting Help for Azure CLI Issues
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 With Azure CLI GitHub Action, you can automate your workflow by executing [Azure CLI](https://github.com/Azure/azure-cli) commands to manage Azure resources inside of an Action.
 
-The action executes the Azure CLI Bash script on a user defined Azure CLI version. If the user does not specify a version, the version of Azure CLI installed on agent is used. If there is no version of Azure CLI found on the agent, then action fall backs the version to `latest`.
+The action executes the Azure CLI Bash script on a user defined Azure CLI version. If the user does not specify a version, the version of Azure CLI installed on agent is used. If there is no version of Azure CLI found on the agent, the action falls back the version to `latest`.
 Read more about various Azure CLI versions [here](https://github.com/Azure/azure-cli/releases).
 
 - `azcliversion` – **Optional** Example: 2.30.0, Default: set to az cli version of the agent.
@@ -24,7 +24,7 @@ The definition of this GitHub Action is in [action.yml](https://github.com/Azure
 ## Sample workflow
 
 ### Dependencies on other GitHub Actions
-* [Azure Login](https://github.com/Azure/login) – **Optional** Login with your Azure credentials, required only for authentication via azure credentials. If you use this action, make sure to either use the default value of `azcliversion` or `azcliversion >= 2.30.0` for all the workflows. Authentication via connection strings or keys do not require this step.
+* [Azure Login](https://github.com/Azure/login) – **Optional** Login with your Azure credentials, required only for authentication via Azure credentials. If you use this action, make sure to either use the default value of `azcliversion` or `azcliversion >= 2.30.0` for all the workflows. Authentication via connection strings or keys do not require this step.
 * [Checkout](https://github.com/actions/checkout) – **Optional** To execute the scripts present in your repository.
 
 ### Workflow to execute an Azure CLI script of a specific CLI version

--- a/README.md
+++ b/README.md
@@ -88,27 +88,6 @@ jobs:
 ```
   * [GITHUB_WORKSPACE](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners) is the environment variable provided by GitHub which represents the root of your repository.
 
-## Azure CLI Action metadata file
-
-```
-# File: action.yml
-
-# Automate your GitHub workflows using Azure CLI scripts.
-name: 'Azure CLI'
-description: 'The action is used to execute Azure CLI commands'
-inputs:
-  inlineScript:
-    description: 'Specify the script here'
-    required: true
-  azcliversion:
-    description: 'Azure CLI version to be used to execute the script'
-    required: false
-    default: 'latest'
-runs:
-  using: 'node16'
-  main: 'lib/main.js'
-```
-
 # Getting Help for Azure CLI Issues
 
 If you encounter an issue related to the Azure CLI commands executed in your script, you can file an issue directly on the [Azure CLI repository](https://github.com/Azure/azure-cli/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 With Azure CLI GitHub Action, you can automate your workflow by executing [Azure CLI](https://github.com/Azure/azure-cli) commands to manage Azure resources inside of an Action.
 
-The action executes the Azure CLI Bash script on a user defined Azure CLI version. If the user does not specify a version, latest CLI version is used.
+The action executes the Azure CLI Bash script on a user defined Azure CLI version. If the user does not specify a version, the version of Azure CLI installed on agent is used. If there is no version of Azure CLI found on the agent, then action fall backs the version to `latest`.
 Read more about various Azure CLI versions [here](https://github.com/Azure/azure-cli/releases).
 
 - `azcliversion` – **Optional** Example: 2.30.0, Default: set to az cli version of the agent.
@@ -13,10 +13,10 @@ Azure CLI GitHub Action is supported for the Azure public cloud as well as Azure
 
 The definition of this GitHub Action is in [action.yml](https://github.com/Azure/CLI/blob/master/action.yml).  The action status is determined by the exit code returned by the script rather than StandardError stream.
 
-## Note
-Please note that the action executes Az CLI script in a docker container. This means that the action is subjected to potential restrictions which arise from containerized execution. For example:
-  1. If script sets up an environment variable, it will not take effect in host and hence subsequent actions shouldn't rely on such environment variable.
-  2. There is some restriction on how cross action file read/write is done. GITHUB_WORKSPACE directory in host is mapped to working directory inside container. So, if the action wants to create a file, which will be read by subsequent actions, it should do so within current working directory tree.
+> [!NOTE]
+> Please note that the action executes Azure CLI script in a docker container. This means that the action is subjected to potential restrictions which arise from containerized execution. For example:
+> 1. If script sets up an environment variable, it will not take effect in host and hence subsequent actions shouldn't rely on such environment variable.
+> 2. There is some restriction on how cross action file read/write is done. GITHUB_WORKSPACE directory in host is mapped to working directory inside container. So, if the action wants to create a file, which will be read by subsequent actions, it should do so within current working directory tree.
 
 > [!WARNING]
 > By default, the output of Azure CLI commands print to the stdout stream and are stored in the build logs of the action. Configure Azure CLI to _not_ show output in the console screen or print in the log by setting the environment variable `AZURE_CORE_OUTPUT` to `none`. If you need the output of a specific command, override the default setting using the argument `--output` with your format of choice. For more information on output options with the Azure CLI, see [Format output](https://learn.microsoft.com/cli/azure/format-output-azure-cli).
@@ -25,10 +25,10 @@ Please note that the action executes Az CLI script in a docker container. This m
 
 ### Dependencies on other GitHub Actions
 * [Azure Login](https://github.com/Azure/login) – **Optional**  Login with your Azure credentials, required only for authentication via azure credentials. Authentication via connection strings or keys do not require this step.
-
-    **Note** Make sure to either use default value of `azcliversion` or version above 2.30.0 for all the workflows using `GitHub hosted agents`.
+    > [!NOTE] Make sure to either use default value of `azcliversion` or version above 2.30.0 for all the workflows using `GitHub hosted agents`.
 * [Checkout](https://github.com/actions/checkout) – **Optional** To execute the scripts present in your repository
-### Workflow to execute an AZ CLI script of a specific CLI version
+
+### Workflow to execute an Azure CLI script of a specific CLI version
 ```
 # File: .github/workflows/workflow.yml
 
@@ -56,7 +56,7 @@ jobs:
           az storage -h
 ```
 
-### Workflow to execute an AZ CLI script of a specific CLI version via file present in your repository.
+### Workflow to execute an Azure CLI script of a specific CLI version via file present in your repository.
 ```
 # File: .github/workflows/workflowForFile.yml
 
@@ -87,34 +87,6 @@ jobs:
           $GITHUB_WORKSPACE/sampleScript.sh
 ```
   * [GITHUB_WORKSPACE](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners) is the environment variable provided by GitHub which represents the root of your repository.
-
-### Configure Azure credentials as GitHub Secret:
-
-To use any credentials like Azure Service Principal,add them as [secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in the GitHub repository and then use them in the workflow.
-
-Follow the steps to configure the secret:
-  * Define a new secret under your repository settings, Add secret menu
-  * Store the output of the below [az cli](https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest) command as the value of secret variable 'AZURE_CREDENTIALS'
-```bash
-
-   az ad sp create-for-rbac --name "myApp" --role contributor \
-                            --scopes /subscriptions/{subscription-id}/resourceGroups/{resource-group} \
-                            --sdk-auth
-
-  # Replace {subscription-id}, {resource-group} with the subscription, resource group details
-
-  # The command should output a JSON object similar to this:
-
-  {
-    "clientId": "<GUID>",
-    "clientSecret": "<GUID>",
-    "subscriptionId": "<GUID>",
-    "tenantId": "<GUID>",
-    (...)
-  }
-
-```
-  * Now in the workflow file in your branch: `.github/workflows/workflow.yml` replace the secret in Azure login action with your secret (Refer to the example above)
 
 ## Azure CLI Action metadata file
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The definition of this GitHub Action is in [action.yml](https://github.com/Azure
 > [!NOTE]
 > Please note that the action executes Azure CLI script in a docker container. This means that the action is subjected to potential restrictions which arise from containerized execution. For example:
 > 1. If script sets up an environment variable, it will not take effect in host and hence subsequent actions shouldn't rely on such environment variable.
-> 2. There is some restriction on how cross action file read/write is done. GITHUB_WORKSPACE directory in host is mapped to working directory inside container. So, if the action wants to create a file, which will be read by subsequent actions, it should do so within current working directory tree.
+> 2. There is some restriction on how cross action file read/write is done. `GITHUB_WORKSPACE` directory in host is mapped to working directory inside container. So, if the action wants to create a file, which will be read by subsequent actions, it should do so within current working directory tree.
 
 > [!WARNING]
 > By default, the output of Azure CLI commands print to the stdout stream and are stored in the build logs of the action. Configure Azure CLI to _not_ show output in the console screen or print in the log by setting the environment variable `AZURE_CORE_OUTPUT` to `none`. If you need the output of a specific command, override the default setting using the argument `--output` with your format of choice. For more information on output options with the Azure CLI, see [Format output](https://learn.microsoft.com/cli/azure/format-output-azure-cli).
@@ -25,7 +25,8 @@ The definition of this GitHub Action is in [action.yml](https://github.com/Azure
 
 ### Dependencies on other GitHub Actions
 * [Azure Login](https://github.com/Azure/login) – **Optional**  Login with your Azure credentials, required only for authentication via azure credentials. Authentication via connection strings or keys do not require this step.
-    > [!NOTE] Make sure to either use default value of `azcliversion` or version above 2.30.0 for all the workflows using `GitHub hosted agents`.
+      > [!NOTE] 
+      > Make sure to either use default value of `azcliversion` or version above 2.30.0 for all the workflows using `GitHub hosted agents`.
 * [Checkout](https://github.com/actions/checkout) – **Optional** To execute the scripts present in your repository
 
 ### Workflow to execute an Azure CLI script of a specific CLI version

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The definition of this GitHub Action is in [action.yml](https://github.com/Azure
 
 ### Dependencies on other GitHub Actions
 * [Azure Login](https://github.com/Azure/login) – **Optional**  Login with your Azure credentials, required only for authentication via azure credentials. Authentication via connection strings or keys do not require this step.
-      > [!NOTE] 
-      > Make sure to either use default value of `azcliversion` or version above 2.30.0 for all the workflows using `GitHub hosted agents`.
+> [!NOTE] 
+> Make sure to either use default value of `azcliversion` or version above 2.30.0 for all the workflows using `GitHub hosted agents`.
 * [Checkout](https://github.com/actions/checkout) – **Optional** To execute the scripts present in your repository
 
 ### Workflow to execute an Azure CLI script of a specific CLI version


### PR DESCRIPTION
https://github.com/Azure/cli/pull/57 changed the default value for `azcliversion` from latest to the version of Azure CLI installed on agent. If there is no version of Azure CLI found on the agent, the action falls back the version to `latest`.
https://github.com/Azure/cli/blob/bb2303375cd17e0282386cca327ba3a341272050/src/main.ts#L32-L44
This pr will update the description about default version used in azure/cli and remove the 'Configure Azure credentials as GitHub Secret' section, since it is not related to azure/cli action, but should be found in https://github.com/Azure/login/blob/master/README.md. And 'Azure CLI Action metadata file' section will be removed, since it is unnecessary to appear in README.md.