### PR TITLE
Update action node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ branding:
   icon: 'login.svg'
   color: 'blue'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Github runners using node16 are being deprecated