### PR TITLE
Add permissions block for upcoming `GITHUB_TOKEN` permission changes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -5,6 +5,9 @@ on:
 
 name: build-release
 
+permissions: 
+  contents: write
+
 jobs:
   build:
     name: build-release


### PR DESCRIPTION
According to https://docs.opensource.microsoft.com/github/apps/permission-changes/
> Starting February 1, 2024 the default permission for the GITHUB_TOKEN will change from Read/Write to Read-only for all Open Source GitHub orgs.

This pr added permissions block to avoid breaking change to our workflow.
