### PR TITLE
{Automation} Modify integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -67,7 +67,6 @@ jobs:
             core.setFailed('Last action should fail but not. Please check it.')
 
   os_test:
-    environment: Automation Test
     runs-on: windows-latest
     steps:
       - uses: azure/login@v1


### PR DESCRIPTION
Since the trigger of integration test is `workflow_dispatch` and `schedule`, and the workflow doesn't check out to the code, environment can be removed in this workflow.