### PR TITLE
Use `process.env` instead of `core.exportvariable` to set env

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ export async function main() {
     let usrAgentRepo = crypto.createHash('sha256').update(`${process.env.GITHUB_REPOSITORY}`).digest('hex');
     let actionName = 'AzureCLIAction';
     let userAgentString = (!!prefix ? `${prefix}+` : '') + `GITHUBACTIONS/${actionName}_${usrAgentRepo}`;
-    core.exportVariable('AZURE_HTTP_USER_AGENT', userAgentString);
+    process.env.AZURE_HTTP_USER_AGENT = userAgentString;
 
     var scriptFileName: string = '';
     const CONTAINER_NAME = `MICROSOFT_AZURE_CLI_${getCurrentTime()}_CONTAINER`;
@@ -86,8 +86,6 @@ export async function main() {
         await deleteFile(scriptFilePath);
         console.log("cleaning up container...");
         await executeDockerCommand(["rm", "--force", CONTAINER_NAME], true);
-        // Reset AZURE_HTTP_USER_AGENT
-        core.exportVariable('AZURE_HTTP_USER_AGENT', prefix);
     }
 };
 


### PR DESCRIPTION
Since setting environment variable for agent is required in current process, there is no need to use core.exportVariable. See https://github.com/actions/toolkit/blob/main/packages/core/README.md#exporting-variables, core.exportVariable is used to add environment variable to this step and future steps environment blocks.

The same implementation as https://github.com/Azure/login/pull/384.