### PR TITLE
FIX: Broken links by appended dot azcliversion errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,8 +41,8 @@ export async function main() {
         }
 
         if (!(await checkIfValidCLIVersion(azcliversion))) {
-            core.error('Please enter a valid azure cli version. \nSee available versions: https://github.com/Azure/azure-cli/releases.');
-            throw new Error('Please enter a valid azure cli version. \nSee available versions: https://github.com/Azure/azure-cli/releases.')
+            core.error('Please enter a valid azure cli version. \nSee available versions: https://github.com/Azure/azure-cli/releases');
+            throw new Error('Please enter a valid azure cli version. \nSee available versions: https://github.com/Azure/azure-cli/releases')
         }
 
         if (!inlineScript.trim()) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ec3b2f84-1a87-4cfc-a614-d68d04d90fa1)

Links are broken on the logs to check newest version of azure cli. 

Super minor fix to remote the dots that are being added to the link